### PR TITLE
Fix read/write deadlock

### DIFF
--- a/src/afs.cc
+++ b/src/afs.cc
@@ -568,7 +568,6 @@ class Processor {
 		auto get_target_size =
 			read ? [](SharedRingBuffer* buffer) { return buffer->rest_size(); }
 				 : [](SharedRingBuffer* buffer) { return buffer->size(); };
-		auto targetSize = get_target_size(buffer);
 		if (runInPGThread_)
 		{
 			while (true)
@@ -591,7 +590,7 @@ class Processor {
 					  peerName,
 					  get_target_size(buffer),
 					  targetSize);
-					if (get_target_size(buffer) != targetSize)
+					if (get_target_size(buffer) > 0)
 					{
 						break;
 					}
@@ -616,7 +615,7 @@ class Processor {
 				{
 					return true;
 				}
-				return get_target_size(buffer) != targetSize;
+				return get_target_size(buffer) > 0;
 			});
 		}
 		return arrow::Status::OK();


### PR DESCRIPTION
Close GH-163

We just need to check whether target size is 0 or greater to detect new readable data/writable space.